### PR TITLE
Updated scripts with new ‘fnserver’ image name.

### DIFF
--- a/FlowSaga/scripts/configure.sh
+++ b/FlowSaga/scripts/configure.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' functions)
+DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' fnserver)
 
 fn apps config set travel COMPLETER_BASE_URL "http://$DOCKER_LOCALHOST:8081"
 

--- a/FlowSaga/scripts/pull-latest.sh
+++ b/FlowSaga/scripts/pull-latest.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-docker pull fnproject/functions:latest
+docker pull fnproject/fnserver:latest
 docker pull fnproject/flow:latest
 docker pull fnproject/flow:ui
 docker pull fnproject/fn-java-fdk-build:latest

--- a/FlowSaga/scripts/start.sh
+++ b/FlowSaga/scripts/start.sh
@@ -4,7 +4,7 @@
 
 sleep 5
 
-DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' functions)
+DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' fnserver)
 
 docker run --rm  \
        -p 8081:8081 \

--- a/FlowSaga/scripts/stop.sh
+++ b/FlowSaga/scripts/stop.sh
@@ -1,3 +1,3 @@
 #! /usr/bin/env bash
 
-docker rm -f functions flow bristol flowui fnui
+docker rm -f fnserver flow bristol flowui fnui


### PR DESCRIPTION
This PR updates the scripts to the new 'fnserver' image name but I still can't get the code running.  The /trip function times out with no output.  The fnserver log looks like:

```sh
time="2017-11-21T22:10:40Z" level=info msg="starting call" action="server.handleRunnerRequest)-fm" app=travel container_id=01BZGA456047WGC00000000000 id=01BZGA452W47WGA00000000000 route=/trip
time="2017-11-21T22:11:11Z" level=info msg="Canceling inactive hot function" app=travel format=http id=01BZGA456047WGC00000000000 idle_timeout=30 image="trip:0.0.218" memory=128 route=/trip
time="2017-11-21T22:11:11Z" level=info msg="hot function terminated" app=travel error="<nil>" format=http id=01BZGA456047WGC00000000000 idle_timeout=30 image="trip:0.0.218" memory=128 route=/trip
```
So this PR fixes an obvious problem but there appear to be other fnserver changes that have broken the saga example.