### PR TITLE
DOCKER_LOCALHOST expression with one that works on Linux and MacOS

### DIFF
--- a/FlowSaga/scripts/configure.sh
+++ b/FlowSaga/scripts/configure.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' fnserver)
+DOCKER_LOCALHOST=$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')
 
 fn apps config set travel COMPLETER_BASE_URL "http://$DOCKER_LOCALHOST:8081"
 

--- a/FlowSaga/scripts/start.sh
+++ b/FlowSaga/scripts/start.sh
@@ -2,7 +2,7 @@
 
 fn start -d
 
-DOCKER_LOCALHOST=$(docker inspect --type container -f '{{.NetworkSettings.Gateway}}' fnserver)
+DOCKER_LOCALHOST=$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}')
 
 docker run --rm  \
        -p 8081:8081 \


### PR DESCRIPTION
Current expression returns "" on Linux resulting in broken URLs.