### PR TITLE
Fit image size to page width

### DIFF
--- a/assets/css/obe-lite.css
+++ b/assets/css/obe-lite.css
@@ -560,6 +560,12 @@ article ul figure figcaption{
     margin: 5px 0px 0px -40px;
 }
 
+/** Fix images mww 3/9/18*/
+img {
+  max-width: 100%;
+  vertical-align: middle;
+}
+
 /* pre and code tags */
 pre {
     -webkit-overflow-scrolling: touch ;


### PR DESCRIPTION
This is a small CSS fix so tutorial images fit within the page width. That is all.