### PR TITLE
Specify the word-flow directory in order to honor the right route

### DIFF
--- a/Flow102/README.md
+++ b/Flow102/README.md
@@ -72,7 +72,7 @@ In a new directory called `word-flow`:
 
 >![user input](../images/userinput.png)
 >```shell
->fn init --runtime=java
+>fn init --runtime=java word-flow
 >```
 
 Flow has a comprehensive test framework, but lets concentrate on playing with the code for the time being:

--- a/Flow102/README.md
+++ b/Flow102/README.md
@@ -68,11 +68,12 @@ bar
 
 ## Creating our Flow function
 
-In a new directory called `word-flow`:
+Run the following command to create a new directory called `word-flow`:
 
 >![user input](../images/userinput.png)
 >```shell
 >fn init --runtime=java word-flow
+>cd word-flow
 >```
 
 Flow has a comprehensive test framework, but lets concentrate on playing with the code for the time being:


### PR DESCRIPTION
This is a nice to have change, since it's really easy to forget to create the directory if just copying/pasting the shell snippets. It also makes the instructions consistent with Flow101.