### PR TITLE
Format fixes. Liquid command fix. Blockquote consistency

### DIFF
--- a/Flow102/README.md
+++ b/Flow102/README.md
@@ -15,7 +15,7 @@ An app which:
   * counts the matching lines
   * prints the count
   * prints the file header
-  
+
 In your shell, it might look something like:
 
 ```shell
@@ -33,28 +33,28 @@ One of the cool things about Fn is that because it's based on Docker, functions 
 
 Clone this repo of simple Bash functions and deploy them all:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >git clone https://github.com/mjg123/fnproject-text-functions.git
 >```
 
 Change directory:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >cd fnproject-text-functions
 >```
 
 Deploy them all:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >fn deploy --local --all
 >```
 
 You can test all of these individually, for example:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >curl -H "Word: bar" -d $' foo \n bar \n baz' http://localhost:8080/r/flow102/grep
 >```
@@ -70,7 +70,7 @@ bar
 
 Run the following command to create a new directory called `word-flow`:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >fn init --runtime=java word-flow
 >cd word-flow
@@ -78,7 +78,7 @@ Run the following command to create a new directory called `word-flow`:
 
 Flow has a comprehensive test framework, but lets concentrate on playing with the code for the time being:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 > rm -rf src/test   ## yolo, again
 >```
@@ -86,7 +86,7 @@ Flow has a comprehensive test framework, but lets concentrate on playing with th
 
 And, make `HelloFunction.java` look like this:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 ```java
 package com.example.fn;
 
@@ -133,35 +133,40 @@ It's worth reading this code carefully, remembering that anything returning a `F
 
 We'll want some test data:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >curl http://www.gutenberg.org/files/1524/1524-0.txt > hamlet.txt
 >```
 
 Set the FLOWSERVER_IP environment variable:
 
->![user input](../images/userinput.png)
->```shell
->FLOWSERVER_IP=$(docker inspect --type container -f '{{.NetworkSettings.IPAddress}}' flowserver)
->```
+![user input](../images/userinput.png)
+<!-- The HTML is required to escape Jekyll Liquid template expressions.
+Otherwise, double brackets and their contents are stripped from output.
+ -->
+<blockquote>
+<pre><code>
+FLOWSERVER_IP=$(docker inspect --type container -f '{{.NetworkSettings.IPAddress}}' flowserver)
+</code></pre>
+</blockquote>
 
 Configure the app with the location of the completer:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >fn config app flow102 COMPLETER_BASE_URL "http://$FLOWSERVER_IP:8081"
 >```
 
 Deploy the function:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >fn deploy --app flow102 --local
 >```
 
 And... send in the Shakespeare:
 
->![user input](../images/userinput.png)
+![user input](../images/userinput.png)
 >```shell
 >curl --data-binary @hamlet.txt http://localhost:8080/r/flow102/word-flow
 >```
@@ -171,7 +176,7 @@ The output looks something like the following:
 ```
 Number of times I found 'love': 76
 
-The first ten lines are: 
+The first ten lines are:
 ...etc etc...
 ```
 
@@ -185,4 +190,4 @@ As you could see from the code above, the `head` and `grep` are executed in para
 
 ## Learn more
 
-Go to the next tutorial [FlowSaga](/FlowSaga/README.md). FlowSaga is a more complex Flow tutorial where you will develop a ployglot travel booking application using Fn Flow. 
+Go to the next tutorial [FlowSaga](/FlowSaga/README.md). FlowSaga is a more complex Flow tutorial where you will develop a ployglot travel booking application using Fn Flow.


### PR DESCRIPTION
Formatting fixes to the flow 102 Readme/tutorial. Prevents Liquid from removing {{ }} from HTML output. Made the user input icons consistent with other tutorials.