### PR TITLE
Add text for node.js dependencies

### DIFF
--- a/node/intro/README.md
+++ b/node/intro/README.md
@@ -143,6 +143,12 @@ The `fn init` command generated two other files.
 input and the output of the function and helps to identify if the function works
 correctly or not. Function testing is not covered in this tutorial.
 
+### Fn and Node.js Dependencies
+Fn handles Node.js dependencies in the following way:
+
+* If a `package.json` is present without a `node_modules` directory, an Fn build runs an `npm install` within the build process and installs your dependencies.
+* If the `node_modules` is present, Fn assumes you have provided the dependencies yourself and no installation is performed.
+
 
 ## Running Your First Function
 With the `nodefn` directory containing `func.js` and `func.yaml` you've


### PR DESCRIPTION
Add Node.js dependency information after configuration file information towards the beginning of the tutorial.
