### PR TITLE
Move Fn context section to install tutorial. Remove from node and go

### DIFF
--- a/Introduction/README.md
+++ b/Introduction/README.md
@@ -8,6 +8,7 @@ about the core Fn concepts like applications and triggers.
 ### Before you Begin
 * Set aside about 15 minutes to complete this tutorial.
 * Make sure Fn server is up and running by completing the [Install and Start Fn Tutorial](../install/README.md).
+    * Make sure you have set your Fn context registry value for local development. (for example, "fndemouser". See [here](../install/README.md).)
 
 As you make your way through this tutorial, look out for this icon. ![User Input
 Icon](images/userinput.png) Whenever you see it, it's time for you to perform an
@@ -21,74 +22,9 @@ machine as Fn provides the necessary Go compiler and tools as a Docker
 container.  Let's walk through your first function to become familiar with the
 process and how Fn supports development.
 
-### Configure your Context
-
-Before we start developing we need to configure Fn to point to an appropriate
-Docker registry so it knows where to push your function images to. Normally
-configure Fn to point to your Docker Hub account by specifying your Docker Hub
-username. However, for pure local development we can simply configure Fn with an
-arbitrary value such as 'fndemouser'.
-
-We store the registry value in an Fn context. An Fn context represents our
-current deployment environment and we can have more than one if we are deploying
-to multiple servers.
-
-First, get a list of available contexts.
-
-![user input](images/userinput.png)
->```sh
-> fn list contexts
->```
-
-The result should be similar to this:
-
-```txt
-CURRENT     NAME    PROVIDER    API URL                    REGISTRY
-            default default     http://localhost:8080/v1   
-```
-
-Notice we have a default context which deploys to a local Fn server. The default context is created the first time you run the Fn CLI. However, we need to select default as our current context and set a registry value to `fndemouser`.
-
-To do that we issue two commands. First select a context:
-
-![user input](images/userinput.png)
->```sh
-> fn use context default
->```
-
-```txt
-Now using context: default
-```
-
-Next, set the Docker registry value:
-
-![user input](images/userinput.png)
->```
-> fn update context registry fndemouser
->```
-
-```txt
-Current context updated registry with fndemouser
-```
-
-Now, recheck your context configuration:
-
-![user input](images/userinput.png)
->```
-> fn list contexts
->```
-
-```txt
-CURRENT     NAME    PROVIDER    API URL                    REGISTRY
-*           default default     http://localhost:8080/v1   fndemouser
-```
-
-The default context is now our current context and has a registry value of `fndemouser`. You are ready to create your first function.
-
 
 ### Create your Function
-With that out of the way, let's create a new function. In the terminal type the
-following.
+In the terminal type the following:
 
 ![User Input Icon](images/userinput.png)
 >```sh

--- a/install/README.md
+++ b/install/README.md
@@ -6,7 +6,7 @@ we'll walk through installing Fn.
 
 Setting up a working Fn installation involves these three simple steps:
 * Ensure you have the necessary prerequisites
-* Download the `fn` command line interface (CLI) utility
+* Download the Fn command line interface (CLI) utility
 * Run `fn start` command which will download the Fn server docker image and start the Fn server
 
 ### Before you Begin
@@ -23,7 +23,7 @@ installed and running.
 ![](images/userinput.png) Whenever you see it, it's time for you to
 perform an action.
 
-## Download and Install the fn CLI
+## Download and Install the Fn CLI
 
 From a terminal type the following:
 
@@ -32,7 +32,7 @@ From a terminal type the following:
 > curl -LSs https://raw.githubusercontent.com/fnproject/cli/master/install | sh
 >```
 
-Once installed you'll see the `fn` CLI version printed out.  You should see
+Once installed you'll see the Fn CLI version printed out.  You should see
 something similar to the following displayed (although likely with a later
 version number):
 
@@ -47,16 +47,17 @@ fn version 0.4.87
 
 ```
 
-**Note:** The above `fn` CLI install script requires write access to restricted folders like /usr/local/bin. If the user doesn't have write access to /usr/local/bin, or if you prefer to install `fn` CLI in a different location, please see the [Fn Manual Install](#fn-manual-install) section.
+**Note:** The above Fn CLI install script requires write access to restricted folders like /usr/local/bin. If the user doesn't have write access to /usr/local/bin, or if you prefer to install Fn CLI in a different location, please see the [Fn Manual Install](#fn-manual-install) section.
 
 ## Start the Fn Server
 
-The final install step is to start the Fn server.  Since Fn runs on
-Docker it'll need to be up and running too.
+The next install step is to start the Fn server.  Since Fn runs on
+Docker it will need to be up and running too.
 
-To start the Fn server you use the `fn` CLI. Run the `fn start` command. This will
-download the Fn server docker image and start the Fn Server on port 8080 by default.
-Note that this process runs in the foreground so that it's easy to stop with Ctrl-C:
+To start the Fn server you use the Fn CLI. Run the `fn start` command. This will
+download the Fn server docker image and start the Fn Server on port 8080 by
+default. Note that this process runs in the foreground so that it is easy to
+stop with Ctrl-C:
 
 ![user input](images/userinput.png)
 >```sh
@@ -85,7 +86,7 @@ time="2018-05-10T11:32:49Z" level=info msg="Fn serving on `:8080`" type=full
 If you have some other process running on port 8080, `fn start` will
 fail with the following error:
 
-```sh
+```txt
 docker: Error response from daemon: driver failed programming external connectivity on endpoint fnserver (d9478f85df4ef97d23d618c2318c243f1e8b65d69ca2547d889d80b148c5be09): Error starting userland proxy: Bind for 0.0.0.0:8080 failed: port is already allocated.
 2018/05/10 16:49:25 error: processed finished with error exit status 125
 ```
@@ -101,7 +102,7 @@ Fn Server starts on port 8080 by default. To use a different port use the `--por
 > fn start -p 8081
 >```
 
-When using a non-default port, you must point the `fn` CLI to the new port using
+When using a non-default port, you must point the Fn CLI to the new port using
 the `FN_API_URL` environment variable:
 
 ![user input](images/userinput.png)
@@ -121,7 +122,7 @@ Let's verify everthing is up and running correctly.
 > fn version
 >```
 
-You should see the version of the fn CLI (client) and server displayed (your
+You should see the version of the Fn CLI (client) and server displayed (your
 version will likely differ):
 
 ```sh
@@ -129,15 +130,110 @@ Client version:  0.4.87
 Server version:  0.3.439
 ```
 
-**Note:** If the server version is "?" then the `fn` CLI cannot reach the Fn server.  
-If this happens it's likely you have something else running on port 8080 or you
-started the server on a different port but forgot to set the `FN_API_URL`.
+**Note:**   
+If the server version is '?' then the Fn CLI cannot reach the Fn server. If this
+happens it's likely you have something else running on port 8080 or you started
+the server on a different port but forgot to set the `FN_API_URL`.
+
+## Configure your Context
+
+Before we start using Fn, we need to configure Fn to point to an appropriate
+Docker registry so it knows where to push your function images to. Normally Fn
+points to your Docker Hub account by specifying your Docker Hub username.
+However, for pure local development we can simply configure Fn with an arbitrary
+value such as "fndemouser".
+
+We store the registry value in an Fn context. An Fn context represents our
+current deployment environment and we can have more than one if we are deploying
+to multiple servers.
+
+### Get a List of Contexts
+
+First, get a list of available contexts.
+
+![user input](images/userinput.png)
+>```sh
+> fn list contexts
+>```
+
+The result should be similar to this:
+
+```txt
+CURRENT     NAME    PROVIDER    API URL                    REGISTRY
+            default default     http://localhost:8080/v1   
+```
+
+Notice we have a default context which deploys to a local Fn server. The default context is created the first time you run the Fn CLI. However, we need to select default as our current context and set a registry value for remote or local Docker use.
+
+### Select a Context
+
+To select a context:
+
+![user input](images/userinput.png)
+>```sh
+> fn use context default
+>```
+
+```txt
+Now using context: default
+```
+
+The default context is now selected.
+
+### Set Registry for Local Development
+To use Fn for local development, set the registry to an arbitrary value. For example:
+
+![user input](images/userinput.png)
+>```
+> fn update context registry fndemouser
+>```
+
+```txt
+Current context updated registry with fndemouser
+```
+
+The Docker registry value is now set to "fndemouser".
+
+### Set Registry for Normal Development
+To use Fn for normal development, set the registry to your Docker Hub user name. For example:
+
+![user input](images/userinput.png)
+>```
+> fn update context registry your-docker-hub-user-name
+>```
+
+```txt
+Current context updated registry with your-docker-hub-user-name
+```
+
+The Docker registry value is now set to your-docker-hub-user-name.
+
+### Verify Context Configuration
+
+Now, recheck your context configuration. If you selected the local development
+option you should get the following results.
+
+![user input](images/userinput.png)
+>```
+> fn list contexts
+>```
+
+```txt
+CURRENT     NAME    PROVIDER    API URL                    REGISTRY
+*           default default     http://localhost:8080/v1   fndemouser
+```
+
+The default context is now our current context and has a registry value of
+`fndemouser`. You are ready to create your first function.
+
+For more information on [contexts see
+here](https://github.com/fnproject/cli/blob/master/CONTEXT.md).
 
 
 ## Fn Manual Install
 The steps to install Fn manually are described in this section. The system requirements are the same as those outlined for the script installation.
 
-You will need to follow these steps if the user doesn't have write access to /usr/local/bin, or if you prefer to install `fn` CLI in a different location.
+You will need to follow these steps if the user doesn't have write access to /usr/local/bin, or if you prefer to install Fn CLI in a different location.
 
 ### Download Fn CLI
 Download the CLI for your operating system. For this example, files are saved to the `~/Downloads` directory.
@@ -194,13 +290,13 @@ Open the Fn project release directory in your browser: <https://github.com/fnpro
 > export PATH=~/lbin:$PATH
 >```
 
-You can confirm using the `which fn` command, the output should look like `/Users/<your-user>/lbin/fn`. Beyond this point you can use `fn` directly.
+You can confirm using the `which fn` command, the output should look like `/Users/<your-user>/lbin/fn`. Beyond this point you can use Fn directly.
 
 (Alternatively, you can use `~/lbin/fn` if you don't want to add to your `PATH` environment variable.)
 
 
 #### For Windows Systems
-The best way for Windows users is to run Fn inside a Linux virtual machine either in the cloud or using [VirtualBox](https://www.virtualbox.org/) on local.
+The best way for Windows users is to run Fn inside a Linux virtual machine either in the cloud or using [VirtualBox](https://www.virtualbox.org/) locally.
 
 
 ## Learn More
@@ -212,6 +308,7 @@ start with:
 * [Go](../Introduction/README.md)
 * [Java](../JavaFDKIntroduction//README.md)
 * [Node.js](../node/intro/README.md)
+* [Python](../python/intro/README.md)
 * [Ruby](../ruby/intro/README.md)
 
 **Go:** [Back to Contents](../README.md)

--- a/node/intro/README.md
+++ b/node/intro/README.md
@@ -8,7 +8,8 @@ triggers.
 
 ### Before you Begin
 * Set aside about 15 minutes to complete this tutorial.
-* Make sure Fn server is up and running by completing the [Install and Start Fn Tutorial](../../install/README.md).
+* Make sure Fn server is up and running by completing the [Install and Start Fn Tutorial](../install/README.md).
+    * Make sure you have set your Fn context registry value for local development. (for example, "fndemouser". See [here](../install/README.md).)
 
 > As you make your way through this tutorial, look out for this icon.
 ![](images/userinput.png) Whenever you see it, it's time for you to
@@ -22,70 +23,9 @@ installed on your development machine as Fn provides the necessary Node tools as
 a Docker container.  Let's walk through your first function to become familiar
 with the process and how Fn supports development.
 
-### Configure your Context
-Before we start developing we need to configure Fn to use a Docker registry.
-Normally, it's set to your Docker Hub username. However in this tutorial we'll
-work in a local development mode, so we will use an arbitrary value
-`fndemouser`. We store the registry value in an Fn context. An Fn context
-represents our current deployment environment and we can have more than one if
-we are deploying to multiple servers.
-
-First, get list of available contexts.
-
-![user input](images/userinput.png)
->```sh
-> fn list contexts
->```
-
-The result should be similar to this:
-
-```txt
-CURRENT     NAME    PROVIDER    API URL                    REGISTRY
-            default default     http://localhost:8080/v1   
-```
-
-Notice we have a default context which deploys to a local Fn server. The default context is created the first time you run the Fn CLI. However, we need to select default as our current context and set a registry value to `fndemouser`.
-
-To do that we issue two commands. First select a context:
-
-![user input](images/userinput.png)
->```sh
-> fn use context default
->```
-
-```txt
-Now using context: default
-```
-
-Next, set the Docker registry value:
-
-![user input](images/userinput.png)
->```
-> fn update context registry fndemouser
->```
-
-```txt
-Current context updated registry with fndemouser
-```
-
-Now, recheck your context configuration:
-
-![user input](images/userinput.png)
->```
-> fn list contexts
->```
-
-```txt
-CURRENT     NAME    PROVIDER    API URL                    REGISTRY
-*           default default     http://localhost:8080/v1   fndemouser
-```
-
-The default context is now our current context and has a registry value of `fndemouser`. You are ready to create your first function.
-
 
 ### Create your Function
-With that out of the way, let's create a new function. In the terminal type the
-following.
+In the terminal type the following.
 
 ![user input](images/userinput.png)
 >```
@@ -475,7 +415,7 @@ The result is once again the same.
 ## Wrap Up
 
 Congratulations!  In this tutorial you've accomplished a lot.  You've created
-your first function and deployed it to your local Fn server and invoked it over
+your first function, deployed it to your local Fn server and invoked it over
 HTTP.
 
 **Go:** [Back to Contents](../README.md)


### PR DESCRIPTION
As stated moving context section into install tutorial. Removing from node and go.