### PR TITLE
Fix various typos in tutorial documentation

### DIFF
--- a/Apps/README.md
+++ b/Apps/README.md
@@ -8,8 +8,8 @@ organize and deploy.
 * Make sure Fn server is up and running by completing the [Install and Start Fn Tutorial](https://github.com/fnproject/tutorials/blob/master/install/README.md).
     * Make sure you have set your Fn context registry value for local development. (for example, "fndemouser". [See here](https://github.com/fnproject/tutorials/blob/master/install/README.md#configure-your-context).)
 
-> As you make your way through this tutorial, look out for this icon.
-![](images/userinput.png) Whenever you see it, it's time for you to
+> As you make your way through this tutorial, look out for this icon:
+![user input](../images/userinput.png). Whenever you see it, it's time for you to
 perform an action.
 
 ## Create an App
@@ -73,7 +73,7 @@ Now we can deploy the entire application with one command:
 
 ![user input](../images/userinput.png)
 >```sh
-> fn deploy --all --local
+> fn deploy --create-app --all --local
 >```
 
 Once the command is done we can examine the structure of the `myapp2` application.  First, get a

--- a/ContainerAsFunction/README.md
+++ b/ContainerAsFunction/README.md
@@ -9,7 +9,7 @@ required to be very Docker-savvy to develop functions with Fn.
 However, sometimes you need to handle advanced use cases and must take
 complete control of the creation of the function container image. Fortunately
 the design and implementation of Fn enables you to do exactly that.  Let's
-build a simple custom function conainer image to become familiar with the key
+build a simple custom function container image to become familiar with the key
 elements of the process.
 
 As you make your way through this tutorial, look out for this icon.
@@ -244,7 +244,7 @@ an application named 'tutorial':
 
 ![](images/userinput.png)
 >```
-> fn deploy --app tutorial --local --no-bump
+> fn deploy --create-app --app tutorial --local --no-bump
 >```
 
 We can confirm the function is correctly defined by getting a list of the

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -88,7 +88,7 @@ This shows the contents of `prometheus.yml` file
 
 The last line ` - targets: ... ` specifies the host name and port of the Fn server from which metrics will be obtained. The name `fnserver` used in this example is defined below in the docker command to start Prometheus server. If you are running a cluster of Fn servers then you can specify them all here.
 
-Check output of the following docker command. This is used in subsequent docker commands to map the docker IP address to the hostnames `fnserver` and `prometheus`.
+Check the output of the following docker command. This is used in subsequent docker commands to map the docker IP address to the hostnames `fnserver` and `prometheus`.
 
 >![user input](../images/userinput.png)
 
@@ -115,8 +115,8 @@ Now start Prometheus, specifying the above config file.
 <div>
 <blockquote>
 <code>docker run --rm --name=prometheus -d -p 9090:9090
- -v &#96;pwd&#96; /prometheus.yml:/etc/prometheus/prometheus.yml
- --add-host=&quot;fnserver:&#96;docker network inspect bridge -f &apos;&#123;&#123;range .IPAM.Config&#125;&#125;&#123;&#123;.Gateway&#125;&#125;&#123;&#123;end&#125;&#125;&apos;&#96;&quot; <br> prom/prometheus</code>
+ -v &#96;pwd&#96;/prometheus.yml:/etc/prometheus/prometheus.yml
+ --add-host=&quot;fnserver:&#96;docker network inspect bridge -f &apos;&#123;&#123;range .IPAM.Config&#125;&#125;&#123;&#123;.Gateway&#125;&#125;&#123;&#123;end&#125;&#125;&apos;&#96;&quot; prom/prometheus</code>
 </blockquote>
 </div>
 


### PR DESCRIPTION
Fixes:
* Spacing issues with commands that prevent copy-pasting them.
* Typo where container was misspelt on /ContainerAsFunction.
* Missing "the" article on /grafana.
* Broken userinput image on /Apps.
* Missing '--create-app' for 'fn deploy' on /Apps and
  /ContainerAsFunction.