### PR TITLE
Oci py example

### DIFF
--- a/python/cloud/oracle/README.md
+++ b/python/cloud/oracle/README.md
@@ -70,6 +70,7 @@ Update your local env with the following [script](oci-instances-func/setup_local
 Run the following command to configure OCI_PRIVATE_KEY_BASE64:
 ```bash
 fn config fn [INPUT_APP_NAME] [INPUT_FUNCTION_NAME] OCI_PRIVATE_KEY_BASE64 $(cat ~/.oci/[INPUT_PRIVATE_KEY_FILE_NAME] | base64)
+```
 
 Updating configuration:
 ```bash

--- a/python/cloud/oracle/README.md
+++ b/python/cloud/oracle/README.md
@@ -67,6 +67,10 @@ fn --verbose deploy --app oci
 
 Update your local env with the following [script](oci-instances-func/setup_local.sh).
 
+Run the following command to configure OCI_PRIVATE_KEY_BASE64:
+```bash
+fn config fn [INPUT_APP_NAME] [INPUT_FUNCTION_NAME] OCI_PRIVATE_KEY_BASE64 $(cat ~/.oci/[INPUT_PRIVATE_KEY_FILE_NAME] | base64)
+
 Updating configuration:
 ```bash
 fn config fn oci list-instances OCI_USER ${OCI_USER}

--- a/python/cloud/oracle/oci-instances-func/setup_local.sh
+++ b/python/cloud/oracle/oci-instances-func/setup_local.sh
@@ -4,6 +4,5 @@ export OCI_USER=`cat ~/.oci/config | grep user | awk '{split($0,array,"=")} END{
 export OCI_TENANCY=`cat ~/.oci/config | grep tenancy | awk '{split($0,array,"=")} END{print array[2]}'`
 export OCI_REGION=`cat ~/.oci/config | grep region | awk '{split($0,array,"=")} END{print array[2]}'`
 export OCI_FINGERPRINT=`cat ~/.oci/config | grep fingerprint | awk '{split($0,array,"=")} END{print array[2]}'`
-export OCI_PRIVATE_KEY_BASE64=`cat $(cat ~/.oci/config | grep key_file | awk '{split($0,array,"=")} END{print array[2]}') | base64`
 export OCI_COMPARTMENT=${OCI_COMPARTMENT:-`cat ~/.oci/config | grep compartment_id | awk '{split($0,array,"=")} END {print array[2]}'`}
 export OCI_PRIVATE_KEY_PASS=${OCI_PRIVATE_KEY_PASS:-""}


### PR DESCRIPTION
Removed following shell command in the shell script because it was not properly reading the key file: 

export OCI_PRIVATE_KEY_BASE64=`cat $(cat ~/.oci/config | grep key_file | awk '{split($0,array,"=")} END{print array[2]}') | base64`

Added new command in README file to configure OCI_PRIVATE_KEY_BASE64: 

fn config fn [APP_NAME] [FUNCTION_NAME]  OCI_PRIVATE_KEY_BASE64 $(cat ~/.oci/[PRIVATE_KEY_FILE_NAME.pem] | base64)
