### PR TITLE
Update pom.xml for requested security updates to jackson-databind

### DIFF
--- a/FlowSaga/flight/book/pom.xml
+++ b/FlowSaga/flight/book/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>[2.9.9.2,)</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/FlowSaga/flight/cancel/pom.xml
+++ b/FlowSaga/flight/cancel/pom.xml
@@ -50,7 +50,7 @@
 	        <dependency>
 	            <groupId>com.fasterxml.jackson.core</groupId>
 	            <artifactId>jackson-databind</artifactId>
-	            <version>2.9.9</version>
+	            <version>[2.9.9.2,)</version>
 	        </dependency>
 	        <dependency>
 	            <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Requested security fix from Github. Bumping jackson-databind from 2.9.9 to 2.9.9.2+.  Requested update to pom.xml is:

```xml
<dependency>
  <groupId>com.fasterxml.jackson.core</groupId>
  <artifactId>jackson-databind</artifactId>
  <version>[2.9.9.2,)</version>
</dependency>
```
If this breaks something the person to blame is clear. 😄 